### PR TITLE
Move setAttribute call off of the constructor

### DIFF
--- a/src/rise-play-until-done.js
+++ b/src/rise-play-until-done.js
@@ -9,10 +9,6 @@ export default class RisePlayUntilDone extends RiseElement {
     this._setVersion( version );
   }
 
-  connectedCallback() {
-    this.setAttribute("play-until-done", true);
-  }
-
   reportDone() {
     super._sendDoneEvent( true );
   }

--- a/src/rise-play-until-done.js
+++ b/src/rise-play-until-done.js
@@ -7,6 +7,9 @@ export default class RisePlayUntilDone extends RiseElement {
     super();
 
     this._setVersion( version );
+  }
+
+  connectedCallback() {
     this.setAttribute("play-until-done", true);
   }
 


### PR DESCRIPTION
## Description
The Web Components [spec says components](https://w3c.github.io/webcomponents/spec/custom/#custom-element-conformance) should not adds attributes in the constructor. This is causing the element to trigger an exception occasionally which affects uptime.

## Motivation and Context
Fix issue https://github.com/Rise-Vision/rise-play-until-done/issues/6 

## How Has This Been Tested?
Tested locally with the component mapped through Charles proxy

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
